### PR TITLE
Enabling common configs (in this case, save frequency) for a policy, …

### DIFF
--- a/continual_rl/experiments/tasks/task_base.py
+++ b/continual_rl/experiments/tasks/task_base.py
@@ -8,7 +8,8 @@ class TaskBase(ABC):
     ALL_TASK_IDS = set()
 
     def __init__(self, task_id, action_space_id, preprocessor, env_spec, observation_space, action_space,
-                 num_timesteps, eval_mode, continual_eval=True):
+                 num_timesteps, eval_mode, continual_eval=True, rolling_return_count=100,
+                 continual_eval_num_returns=10):
         """
         Subclasses of TaskBase contain all information that should be consistent within a task for everyone
         trying to use it for a baseline. In other words anything that should be kept comparable, should be specified
@@ -25,6 +26,10 @@ class TaskBase(ABC):
         :param num_timesteps: The total number of timesteps this task should run
         :param eval_mode: Whether this environment is being run in eval_mode (i.e. training should not occur)
         should end.
+        :param continual_eval: Whether the task should be run during continual evaluation collections
+        :param rolling_return_count: How many returns in the rolling mean (Default is the number OpenAI baselines uses.)
+        :param continual_eval_num_returns: How many episodes to run while doing continual evaluation.
+        These should be collected by a single environment: see note in policy_base.get_environment_runner
         """
         self.action_space_id = action_space_id
         self.action_space = action_space
@@ -35,15 +40,11 @@ class TaskBase(ABC):
 
         # We keep running mean of rewards so the average is less dependent on how many episodes completed
         # in the last update
-        self._rolling_return_count = 100  # The number OpenAI baselines uses. Represents # rewards to keep between logs
-
-        # How many episodes to run while doing continual evaluation.
-        # These should be collected by a single environment: see note in policy_base.get_environment_runner
-        continual_eval_num_returns = 10
+        self._rolling_return_count = rolling_return_count
 
         # The set of task parameters that the environment runner gets access to.
         self._task_spec = TaskSpec(self.task_id, action_space_id, preprocessor, env_spec, num_timesteps, eval_mode,
-                                   continual_eval=continual_eval)
+                                   with_continual_eval=continual_eval)
 
         # A version of the task spec to use if we're in forced-eval mode. The collection will end when
         # the first reward is logged, so the num_timesteps just needs to be long enough to allow for that.

--- a/continual_rl/experiments/tasks/task_spec.py
+++ b/continual_rl/experiments/tasks/task_spec.py
@@ -7,7 +7,7 @@ class TaskSpec(object):
     EnvironmentRunner.
     """
     def __init__(self, task_id, action_space_id, preprocessor, env_spec, num_timesteps, eval_mode,
-                 return_after_episode_num=None, continual_eval=True):
+                 return_after_episode_num=None, with_continual_eval=True):
         self._task_id = task_id
         self._action_space_id = action_space_id
         self._preprocessor = preprocessor
@@ -15,7 +15,7 @@ class TaskSpec(object):
         self._num_timesteps = num_timesteps
         self._eval_mode = eval_mode
         self._return_after_episode_num = return_after_episode_num
-        self.with_continual_eval = continual_eval
+        self._with_continual_eval = with_continual_eval
 
     @property
     def task_id(self):
@@ -70,3 +70,10 @@ class TaskSpec(object):
         finishes, it might put the total number of episodes over this number.
         """
         return self._return_after_episode_num
+
+    @property
+    def with_continual_eval(self):
+        """
+        Whether the task should be run during continual evaluation collection
+        """
+        return self._with_continual_eval

--- a/continual_rl/policies/config_base.py
+++ b/continual_rl/policies/config_base.py
@@ -20,6 +20,7 @@ class ConfigBase(ABC):
     """
     def __init__(self):
         self._output_dir = None  # Output dir for the current run of the experiment, accessible as self.output_dir
+        self.timesteps_per_save = 3e4
 
     def set_output_dir(self, set_output_dir):
         self._output_dir = set_output_dir

--- a/continual_rl/policies/discrete_random/discrete_random_policy.py
+++ b/continual_rl/policies/discrete_random/discrete_random_policy.py
@@ -12,7 +12,7 @@ class DiscreteRandomPolicy(PolicyBase):
     Refer to policy_base itself for more detailed descriptions of the method signatures.
     """
     def __init__(self, config: DiscreteRandomPolicyConfig, observation_space, action_spaces):
-        super().__init__()
+        super().__init__(config)
         self._config = config
         self._action_spaces = action_spaces
 

--- a/continual_rl/policies/impala/impala_policy.py
+++ b/continual_rl/policies/impala/impala_policy.py
@@ -17,7 +17,7 @@ class ImpalaPolicy(PolicyBase):
     """
     def __init__(self, config: ImpalaPolicyConfig, observation_space, action_spaces, impala_class: Monobeast = None,
                  policy_net_class: ImpalaNet = None):
-        super().__init__()
+        super().__init__(config)
         self._config = config
         self._action_spaces = action_spaces
 

--- a/continual_rl/policies/play/play_policy.py
+++ b/continual_rl/policies/play/play_policy.py
@@ -27,7 +27,7 @@ class PlayPolicy(PolicyBase):
     # https://github.com/openai/gym/blob/master/gym/envs/atari/atari_env.py
 
     def __init__(self, config: PlayPolicyConfig, observation_space, action_spaces):
-        super().__init__()
+        super().__init__(config)
 
         if not isinstance(action_spaces[0], gym.spaces.Discrete):
             raise Exception('Keyboard agent only supports discrete action spaces')

--- a/continual_rl/policies/policy_base.py
+++ b/continual_rl/policies/policy_base.py
@@ -6,7 +6,7 @@ class PolicyBase(ABC):
     """
     The base class that all agents should implement, enabling them to act in the world.
     """
-    def __init__(self):
+    def __init__(self, config):
         """
         Subclass policies will always be initialized with: (config, observation_space, action_spaces).
         No other parameters should be added - the policy won't be loaded with them from the configuration loader.
@@ -14,7 +14,7 @@ class PolicyBase(ABC):
         observation_space is the common observation space for all tasks
         action_spaces is a map from action_space_id to the action space for a given task.
         """
-        pass
+        self.config = config
 
     def set_task_ids(self, task_ids):
         """

--- a/continual_rl/policies/ppo/ppo_policy.py
+++ b/continual_rl/policies/ppo/ppo_policy.py
@@ -23,7 +23,7 @@ class PPOPolicy(PolicyBase):
     and the rest are subsets.
     """
     def __init__(self, config: PPOPolicyConfig, observation_space, action_spaces):  # Switch to your config type
-        super().__init__()
+        super().__init__(config)
         max_action_space = Utils.get_max_discrete_action_space(action_spaces)
         self._action_spaces = action_spaces
 

--- a/continual_rl/policies/prototype/prototype_policy.py
+++ b/continual_rl/policies/prototype/prototype_policy.py
@@ -9,7 +9,7 @@ class PrototypePolicy(PolicyBase):
     Refer to policy_base itself for more detailed descriptions of the method signatures.
     """
     def __init__(self, config: PrototypePolicyConfig, observation_space, action_spaces):  # Switch to your config type
-        super().__init__()
+        super().__init__(config)
         self._config = config
         self._observation_space = observation_space
         self._action_spaces = action_spaces

--- a/continual_rl/utils/env_wrappers.py
+++ b/continual_rl/utils/env_wrappers.py
@@ -54,7 +54,7 @@ class NoopResetEnv(gym.Wrapper):
         if self.override_num_noops is not None:
             noops = self.override_num_noops
         else:
-            noops = self.unwrapped.np_random.randint(1, self.noop_max + 1) #pylint: disable=E1101
+            noops = self.unwrapped.np_random.integers(1, self.noop_max + 1)
         assert noops > 0
         obs = None
         for _ in range(noops):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
                       'numpy',
                       'tensorboard',
                       'torch-ac',
-                      'gym[atari]',
+                      'gym[atari]<=0.25.2',
                       'atari-py==0.2.5',
                       'moviepy',
                       'dotmap',

--- a/tests/common_mocks/mock_policy/mock_policy.py
+++ b/tests/common_mocks/mock_policy/mock_policy.py
@@ -9,9 +9,11 @@ class MockPolicy(PolicyBase):
     For any test-specific usages, monkeypatch the appropriate function.
     """
     def __init__(self, config: MockPolicyConfig, observation_space, action_spaces):
-        super().__init__()
+        super().__init__(config)
         self._config = config
         self.train_run_count = 0
+        self.load_count = 0
+        self.save_count = 0
         self.current_env_runner = None
 
     def get_environment_runner(self, task_spec):
@@ -25,8 +27,8 @@ class MockPolicy(PolicyBase):
     def train(self, storage_buffer):
         self.train_run_count += 1
 
-    def save(self, output_path_dir, task_id, task_total_steps):
-        pass
+    def save(self, output_path_dir, cycle_id, task_id, task_total_steps):
+        self.save_count += 1
 
     def load(self, model_path):
-        pass
+        self.load_count += 1

--- a/tests/experiments/test_experiment.py
+++ b/tests/experiments/test_experiment.py
@@ -1,6 +1,10 @@
 import pytest
+import os
+from pathlib import Path
 from continual_rl.experiments.experiment import Experiment, InvalidTaskAttributeException
 from tests.common_mocks.mock_task import MockTask
+from tests.common_mocks.mock_policy.mock_policy import MockPolicy
+from tests.common_mocks.mock_policy.mock_policy_config import MockPolicyConfig
 
 
 class TestExperiment(object):
@@ -68,3 +72,56 @@ class TestExperiment(object):
         # Act & Assert
         with pytest.raises(InvalidTaskAttributeException):
             Experiment._get_action_spaces(fake_tasks)
+
+    def test_policy_save(self, set_tmp_directory, cleanup_experiment, request):
+        """
+        Tests that the policy's save functionality is being called per the configuration
+        """
+        # Arrange
+        output_dir = Path(request.node.experiment_output_dir, "test_policy_save")
+        os.makedirs(output_dir)
+
+        experiment = Experiment(tasks=[
+            MockTask(task_id="save_test_0", action_space_id=12, env_spec=None, action_space=5, time_batch_size=3,
+                     num_timesteps=100, eval_mode=None)])
+        experiment.set_output_dir(output_dir)
+
+        config = MockPolicyConfig()
+        config.timesteps_per_save = 20
+        policy = MockPolicy(config, None, None)
+
+        # Act
+        experiment.try_run(policy, None)  # Runs 10 timesteps every call (per the mock)
+
+        # Assert
+        assert policy.save_count == 7  # One at the start and an extra one at the end
+        assert policy.load_count == 1
+
+    def test_multitask_policy_save(self, set_tmp_directory, cleanup_experiment, request):
+        """
+        Tests that the policy's save functionality is being called per the configuration
+        """
+        # Arrange
+        output_dir = Path(request.node.experiment_output_dir, "test_multitask_policy_save")
+        os.makedirs(output_dir)
+
+        experiment = Experiment(tasks=[
+            MockTask(task_id="save_test_1", action_space_id=12, env_spec=None, action_space=5, time_batch_size=3,
+                     num_timesteps=80, eval_mode=None),
+            MockTask(task_id="save_test_2", action_space_id=12, env_spec=None, action_space=5, time_batch_size=3,
+                     num_timesteps=80, eval_mode=None),
+            MockTask(task_id="save_test_3", action_space_id=12, env_spec=None, action_space=5, time_batch_size=3,
+                     num_timesteps=80, eval_mode=None)
+        ])
+        experiment.set_output_dir(output_dir)
+
+        config = MockPolicyConfig()
+        config.timesteps_per_save = 20
+        policy = MockPolicy(config, None, None)
+
+        # Act
+        experiment.try_run(policy, None)  # Runs 10 timesteps every call (per the mock)
+
+        # Assert
+        assert policy.save_count == 18  # One at the start and an extra one at the end
+        assert policy.load_count == 1


### PR DESCRIPTION
…which can be specified via config file or command line as normal. Also making it so task params can be passed in (though presently they're just left as the defaults). Also gym 0.26 is not backwards compatible, so enforcing an older version for now, since updating the codebase is less trivial. Also fixed one of the deprecation issues.